### PR TITLE
Add support for PHP 7.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `socialite-passport` will be documented in this file
 
+## 1.0.3
+- Lower the required PHP version from 7.4 to 7.2
+
 ## 1.0.2
 - Updated default controller class to `\App\Http\Controllers\Auth\LoginController::class`
 - Updated default controller method to `loginWithPassport()`

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.2",
         "illuminate/support": "^6.0",
         "socialiteproviders/laravelpassport": "^1.0",
         "laravel/socialite": "^4.3"

--- a/src/SocialitePassportServiceProvider.php
+++ b/src/SocialitePassportServiceProvider.php
@@ -26,6 +26,8 @@ class SocialitePassportServiceProvider extends ServiceProvider
 
         $this->app->register(EventServiceProvider::class);
 
-        $this->app->bind('AuthenticationController', fn() => new AuthenticationController());
+        $this->app->bind('AuthenticationController', function () {
+            return new AuthenticationController();
+        });
     }
 }


### PR DESCRIPTION
As requested in issue #1, this PR adds support for PHP versions 7.2 and up.

This will be added in version **1.0.3** of the package.